### PR TITLE
separated onboarding and pairing, added pairing logic

### DIFF
--- a/app/(home)/home-page.tsx
+++ b/app/(home)/home-page.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import React from "react";
+
+const page = () => {
+  return (
+    <View className="flex-1 items-center justify-center bg-primary">
+      <Text className="text-lg text-black">welcome home!</Text>
+    </View>
+  );
+};
+
+export default page;

--- a/app/(onboard)/create-room.tsx
+++ b/app/(onboard)/create-room.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { useRouter } from 'expo-router';
+import { supabase } from '@/config/db';
+import * as Clipboard from 'expo-clipboard';
+import Button from '@/components/Button';
+import { View, Text, Platform, Image, TextInput, Alert } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+function PairingStep({
+  myCode,
+  setPartnerCode,
+  partnerCode,
+  onFinish,
+  error,
+}: {
+  myCode: string;
+  partnerCode: string;
+  setPartnerCode: (s: string) => void;
+  onFinish: () => void;
+  error: string;
+}) {
+  const handleCopy = async () => {
+    if (!myCode || myCode.length === 0) {
+      Alert.alert('Error', 'No code available to copy.');
+      return;
+    }
+    await Clipboard.setStringAsync(myCode);
+    Alert.alert('Copied', 'Invite code copied to clipboard!');
+  };
+
+  return (
+    <View className="w-full max-w-xs items-center">
+      <Text className="text-2xl font-bold text-accent mb-4 text-center">
+        Pair with your partner
+      </Text>
+
+      <Text className="text-base font-medium text-white mb-2">Your code:</Text>
+      <View className="bg-white px-4 py-2 rounded-lg mb-3 w-full items-center">
+        <Text className="text-lg font-bold text-black tracking-widest">
+          {myCode}
+        </Text>
+      </View>
+      <Button
+        label="Copy code"
+        onPress={handleCopy}
+        size="py-2"
+        color="bg-gray-300"
+        className="w-full mb-4"
+        textClassName="text-black"
+      />
+
+      <Text className="text-base text-white mt-4 mb-1">
+        Enter partner's code
+      </Text>
+      <TextInput
+        value={partnerCode}
+        onChangeText={setPartnerCode}
+        placeholder="XXXXXX"
+        className="bg-white px-4 py-2 rounded-lg mb-4 w-full text-center text-lg tracking-widest"
+        autoCapitalize="characters"
+      />
+      
+      <View className="flex-row w-full">
+        <Button
+          label="Pair now"
+          onPress={onFinish}
+          size="py-3"
+          color="bg-accent"
+          className="w-1/2 ml-2"
+          textClassName="text-white"
+        />
+      </View>
+
+      {error && (
+        <Text className="text-red-500 text-center mb-4">
+          {error}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const createRoom = () => {
+const router = useRouter(); 
+  const { userId, roomId } = useLocalSearchParams();
+  const roomIdString = Array.isArray(roomId) ? roomId[0] : roomId;
+  const [partnerCode, setPartnerCode] = useState('');
+  const [myCode] = useState(roomIdString);
+  const [error, setError] = useState('');
+
+  const connectRoom = async () => {
+    if (partnerCode === myCode) {
+        setError('Cannot enter your own code');
+        return;
+    }
+    try {
+      const { error: coupleError } = await supabase
+        .from('room')
+        .update({ 
+            user_2: userId, filled: true }) 
+        .eq('room_id', partnerCode)
+        .is('user_2', null)
+        .select();
+  
+      if (coupleError) throw coupleError;
+  
+      // Delete user2's database after pairing 
+      const { error: deleteRoomError } = await supabase
+        .from('room')
+        .delete()
+        .eq('room_id', myCode)
+
+      if (deleteRoomError) throw deleteRoomError;
+
+      // Success feedback and navigation  
+      console.log('Paired with partner successfully!');
+      Alert.alert('Success', 'You have been paired with your partner!');
+      router.push('/(home)/home-page'); // Replace with your next route
+    } catch (err) {
+      console.error('Pairing failed:', err);
+      setError('Failed to pair with your partner. Please try again.');
+    }
+  };
+
+  return (
+        <View className="flex-1 items-center justify-center bg-primary px-4">
+                <PairingStep myCode={myCode} 
+                partnerCode={partnerCode}
+                setPartnerCode={setPartnerCode}
+                onFinish={connectRoom}
+                error = {error}></PairingStep>
+        </View>
+    );
+};
+
+
+export default createRoom;

--- a/app/(onboard)/onboardingFlow.tsx
+++ b/app/(onboard)/onboardingFlow.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { useRouter } from 'expo-router';
-import { View, Text, Platform, Image, TextInput } from 'react-native';
+import { View, Text, Platform, Image, TextInput, Alert } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import * as ImagePicker from 'expo-image-picker';
 import Button from '@/components/Button';
+import * as Clipboard from 'expo-clipboard';
 import { useLocalSearchParams } from 'expo-router';
 import { supabase } from '@/config/db';
 
@@ -127,12 +128,12 @@ async function pickImage(setPhoto: (uri: string) => void) {
 function PhotoStep({
   photo,
   setPhoto,
-  onFinish,
+  onNext,
   onPrevious,
 }: {
   photo: string | null;
   setPhoto: (uri: string) => void;
-  onFinish: () => void;
+  onNext: () => void;
   onPrevious?: () => void;
 }) {
   return (
@@ -166,13 +167,84 @@ function PhotoStep({
         />
       )}
       <Button
-        label="Finish"
-        onPress={onFinish}
+        label="Next"
+        onPress={onNext} // Still using `onFinish` to go to next step (setStep(3))
         size="px-4 py-3"
         color="bg-accent"
         className="w-full"
         textClassName="text-white text-base font-medium"
       />
+    </View>
+  );
+}
+function PairingStep({
+  myCode,
+  setPartnerCode,
+  partnerCode,
+  onPrevious,
+  onFinish,
+}: {
+  myCode: string;
+  partnerCode: string;
+  setPartnerCode: (s: string) => void;
+  onPrevious: () => void;
+  onFinish: () => void;
+}) {
+  const handleCopy = async () => {
+    await Clipboard.setStringAsync(myCode);
+    Alert.alert('Copied', 'Invite code copied to clipboard!');
+  };
+
+  return (
+    <View className="w-full max-w-xs items-center">
+      <Text className="text-2xl font-bold text-accent mb-4 text-center">
+        Pair with your partner
+      </Text>
+
+      <Text className="text-base font-medium text-white mb-2">Your code:</Text>
+      <View className="bg-white px-4 py-2 rounded-lg mb-3 w-full items-center">
+        <Text className="text-lg font-bold text-black tracking-widest">
+          {myCode}
+        </Text>
+      </View>
+      <Button
+        label="Copy code"
+        onPress={handleCopy}
+        size="py-2"
+        color="bg-gray-300"
+        className="w-full mb-4"
+        textClassName="text-black"
+      />
+
+      <Text className="text-base text-white mt-4 mb-1">
+        Enter partner's code
+      </Text>
+      <TextInput
+        value={partnerCode}
+        onChangeText={setPartnerCode}
+        placeholder="XXXXXX"
+        className="bg-white px-4 py-2 rounded-lg mb-4 w-full text-center text-lg tracking-widest"
+        autoCapitalize="characters"
+      />
+
+      <View className="flex-row w-full">
+        <Button
+          label="Previous"
+          onPress={onPrevious}
+          size="py-3"
+          color="bg-gray-400"
+          className="w-1/2 mr-2"
+          textClassName="text-white"
+        />
+        <Button
+          label="Pair now"
+          onPress={onFinish}
+          size="py-3"
+          color="bg-accent"
+          className="w-1/2 ml-2"
+          textClassName="text-white"
+        />
+      </View>
     </View>
   );
 }
@@ -188,57 +260,76 @@ const OnboardingFlow = () => {
   const [photo, setPhoto] = useState<string | null>(null);
   const { userId, email } = useLocalSearchParams();
   const router = useRouter();
+const [myCode] = useState('034FJ'); // You can generate dynamically later
+const [partnerCode, setPartnerCode] = useState('');
 
-  const handleFinish = async () => {
-    try {
-      const { data, error } = await supabase
-        .from('users')
-        .insert([
-          {
-            email: email,
-            user_id: userId,
-            username: name,
-            birthdate: birthdate,
-            photo_url: photo,
-            created_at: new Date().toISOString(),
-          },
-        ])
-        .select(); // ← now `data` is the array of inserted rows
+const handleFinish = async () => {
+  try {
+    // 1. Save user to `users` table
+    const { data: userData, error: userError } = await supabase
+      .from('users')
+      .insert([
+        {
+          email: email,
+          user_id: userId,
+          username: name,
+          birthdate: birthdate,
+          photo_url: photo,
+          created_at: new Date().toISOString(),
+        },
+      ])
+      .select();
 
-      if (error) {
-        throw error;
-      }
-      console.log('User saved successfully:', data);
-      router.push('/page');
-    } catch (error) {
-      console.error(error);
-    }
-  };
+    if (userError) throw userError;
 
-  const steps = [
-    <NameStep
-      key="1"
-      name={name}
-      setName={setName}
-      onNext={() => setStep(1)}
-    />,
-    <BirthdayStep
-      key="2"
-      birthdate={birthdate}
-      setBirthdate={setBirthdate}
-      showPicker={showPicker}
-      setShowPicker={setShowPicker}
-      onPrevious={() => setStep(0)}
-      onNext={() => setStep(2)}
-    />,
-    <PhotoStep
-      key="3"
-      photo={photo}
-      setPhoto={setPhoto}
-      onPrevious={() => setStep(1)}
-      onFinish={handleFinish}
-    />,
-  ];
+    console.log('User saved successfully:', userData);
+
+    // 2. Update pairing in `couples` table
+    const { error: coupleError } = await supabase
+      .from('couples')
+      .update({ user2_id: userId }) // assumes the partner already created the code
+      .eq('invite_code', partnerCode)
+      .is('user2_id', null); // make sure not already paired
+
+    if (coupleError) throw coupleError;
+
+    console.log('Paired with partner successfully!');
+    router.push('/page'); // Redirect to app
+  } catch (error) {
+    console.error('Onboarding failed:', error);
+    Alert.alert('Error', 'Failed to complete onboarding.');
+  }
+};
+
+
+const steps = [
+  <NameStep key="1" name={name} setName={setName} onNext={() => setStep(1)} />,
+  <BirthdayStep
+    key="2"
+    birthdate={birthdate}
+    setBirthdate={setBirthdate}
+    showPicker={showPicker}
+    setShowPicker={setShowPicker}
+    onPrevious={() => setStep(0)}
+    onNext={() => setStep(2)}
+  />,
+  <PhotoStep
+    key="3"
+    photo={photo}
+    setPhoto={setPhoto}
+    onPrevious={() => setStep(1)}
+    onNext={() => setStep(3)}
+  />,
+  <PairingStep
+    key="4"
+    myCode={myCode}
+    partnerCode={partnerCode}
+    setPartnerCode={setPartnerCode}
+    onPrevious={() => setStep(2)}
+    onFinish={handleFinish}
+  />,
+];
+
 
   return (
     <View className="flex-1 items-center justify-center bg-primary px-4">

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo": "^52.0.44",
         "expo-auth-session": "~6.0.3",
         "expo-blur": "~14.0.3",
+        "expo-clipboard": "^7.1.4",
         "expo-constants": "~17.0.8",
         "expo-font": "~13.0.4",
         "expo-haptics": "~14.0.1",
@@ -9032,6 +9033,17 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-14.0.3.tgz",
       "integrity": "sha512-BL3xnqBJbYm3Hg9t/HjNjdeY7N/q8eK5tsLYxswWG1yElISWZmMvrXYekl7XaVCPfyFyz8vQeaxd7q74ZY3Wrw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.4.tgz",
+      "integrity": "sha512-NHhfKnrzb4o0PacUKD93ByadU0JmPBoFTFYbbFJZ9OAX6SImpSqG5gfrMUR3vVj4Qx9f1LpMcdAv5lBzv868ow==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "expo": "^52.0.44",
     "expo-auth-session": "~6.0.3",
     "expo-blur": "~14.0.3",
+    "expo-clipboard": "^7.1.4",
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",
     "expo-haptics": "~14.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,6 +4526,11 @@ expo-blur@~14.0.3:
   resolved "https://registry.npmjs.org/expo-blur/-/expo-blur-14.0.3.tgz"
   integrity sha512-BL3xnqBJbYm3Hg9t/HjNjdeY7N/q8eK5tsLYxswWG1yElISWZmMvrXYekl7XaVCPfyFyz8vQeaxd7q74ZY3Wrw==
 
+expo-clipboard@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.4.tgz"
+  integrity sha512-NHhfKnrzb4o0PacUKD93ByadU0JmPBoFTFYbbFJZ9OAX6SImpSqG5gfrMUR3vVj4Qx9f1LpMcdAv5lBzv868ow==
+
 expo-constants@*, expo-constants@~17.0.5, expo-constants@~17.0.8:
   version "17.0.8"
   resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.8.tgz"
@@ -4958,11 +4963,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -6183,10 +6183,10 @@ lighthouse-logger@^1.0.0:
     debug "^2.6.9"
     marky "^1.2.2"
 
-lightningcss-darwin-arm64@1.27.0:
+lightningcss-win32-x64-msvc@1.27.0:
   version "1.27.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz"
-  integrity sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==
+  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz"
+  integrity sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==
 
 lightningcss@^1.27.0, lightningcss@~1.27.0:
   version "1.27.0"


### PR DESCRIPTION
## 🚀 What does this PR do?

> A short summary of what’s changed and why.
This pull request contains these changes:
- Split onboarding and pairing page into 2 different things (once at pairing page, cannot go back to onboarding steps anymore)
- Added pairing logic: create rooms with unique IDs for each user, allow connecting with another user via code, remove the room of user who enters the code to clean up the space, and direct to the homepage after pairing.

---

## ✅ Checklist

- [ ] Code compiles & runs
- [ ] Lint checks pass
- [ ] Updated `.env.example` if needed
- [ ] PR linked to related issue/ticket (if applicable)

---

## 🔍 How to test this

The screenshots below test that:

- A person cannot enter their own code (there's error message telling them to change)
- The pairing is working: updated table 'room', update status of the "filled" column to "TRUE", redirected to homepage
- After pairing, the room entry of the person who enters the invite code is deleted (there is only 1 row)

> Describe how reviewers can test this — steps, screenshots, etc.
<img width="719" alt="supabase-room" src="https://github.com/user-attachments/assets/e53be410-e275-4088-9ed9-358c712567f7" />
<img width="249" alt="pairing-successful" src="https://github.com/user-attachments/assets/63cbfbc2-3be6-4158-8095-876157447455" />
<img width="287" alt="pair-different-code" src="https://github.com/user-attachments/assets/6c1eb9c0-4522-41b6-a6ee-fc6ae2beb380" />
<img width="280" alt="copy-own-code" src="https://github.com/user-attachments/assets/3c0abc22-7d2c-4c1a-87ca-3dc783363d36" />

---

## 🧠 Extra Notes

> Any decisions made? Tradeoffs? Gotchas?
