### PR TITLE
Dat/phone support

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,12 +10,18 @@ import LibraryRouter from './routes/libraryRoutes';
 dotenv.config();
 
 const app = express();
-const PORT = process.env.PORT;
-const LOCAL_HOST_URL = process.env.LOCAL_HOST_URL;
+const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
+const LOCAL_URL = process.env.LOCAL_URL;
+const PUBLIC_URL = process.env.PUBLIC_URL;
 
 app.use(express.json({ limit: '20mb' })); // For JSON payloads
 app.use(express.urlencoded({ limit: '20mb', extended: true }));
-app.use(cors()); // allows the backend to respond to requests from the frontend.
+app.use(
+  cors({
+    origin: [LOCAL_URL, PUBLIC_URL].filter((u): u is string => !!u),
+  }),
+);
+
 
 // Route mounting
 app.use('/users', UserRouter);
@@ -57,8 +63,13 @@ const startServer = async () => {
     console.log('✅ users schema and columns OK');
 
     // 4) All good—start listening
-    app.listen(PORT, () => {
-      console.log(`🚀 Server running at ${LOCAL_HOST_URL}:${PORT}`);
+    if (!PORT) {
+      throw new Error('🚨 PORT is not defined or invalid.');
+    }
+    app.listen(PORT, '0.0.0.0', () => {
+      console.log('✅ Server listening on port', PORT);
+      console.log('✅ Local endpoint:', LOCAL_URL);
+      console.log('✅ Public endpoint:', PUBLIC_URL);
     });
   } catch (err: any) {
     console.error('🚨 Failed to start server:', err.message || err);

--- a/frontend/src/apis/apiClient.ts
+++ b/frontend/src/apis/apiClient.ts
@@ -1,0 +1,18 @@
+// src/api/apiClient.ts
+import { Platform } from 'react-native';
+
+const HOST = process.env.EXPO_PUBLIC_API_HOST!;
+const PORT = process.env.EXPO_PUBLIC_API_PORT!;
+const PUBLIC_URL = process.env.EXPO_PUBLIC_API_PUBLIC_URL!;
+
+if (!HOST || !PORT || !PUBLIC_URL) {
+  throw new Error(
+    'Define EXPO_PUBLIC_API_HOST, EXPO_PUBLIC_API_PORT & EXPO_PUBLIC_API_PUBLIC_URL in .env',
+  );
+}
+
+const LOCAL_URL = `http://${HOST}:${PORT}`;
+
+// web → LOCAL_URL
+// On a real device or stimulator → PUBLIC_URL
+export const BASE_URL = Platform.OS === 'web' ? LOCAL_URL : PUBLIC_URL;

--- a/frontend/src/apis/library.ts
+++ b/frontend/src/apis/library.ts
@@ -1,12 +1,7 @@
 import { Book, CreateBookDTO, UpdateBookDTO } from '../types/library';
+import { BASE_URL } from './apiClient';
 
-const host = process.env.EXPO_PUBLIC_API_HOST;
-const port = process.env.EXPO_PUBLIC_API_PORT;
-
-if (!host || !port) {
-  throw new Error('Missing LOCAL_HOST_URL or PORT in your environment');
-}
-const BASE_URL = `${host}:${port}`;
+console.log('BASE_URL:', BASE_URL);
 
 export const libraryApi = {
   createBook: async (book: CreateBookDTO): Promise<Book> => {

--- a/frontend/src/apis/room.ts
+++ b/frontend/src/apis/room.ts
@@ -6,14 +6,9 @@ import {
   FetchRoomRequest,
   FetchRoomResponse,
 } from '@/types/rooms';
+import { BASE_URL } from './apiClient';
 
-const host = process.env.EXPO_PUBLIC_API_HOST;
-const port = process.env.EXPO_PUBLIC_API_PORT;
-
-if (!host || !port) {
-  throw new Error('Missing LOCAL_HOST_URL or PORT in your environment');
-}
-const BASE_URL = `${host}:${port}`;
+console.log('BASE_URL:', BASE_URL);
 
 export async function createRoom(request: RoomRequest): Promise<CreatedRoom> {
   try {

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -5,14 +5,9 @@ import {
   OnboardResponse,
   FetchedUserResponse,
 } from '@/types/users';
+import { BASE_URL } from './apiClient';
 
-const host = process.env.EXPO_PUBLIC_API_HOST;
-const port = process.env.EXPO_PUBLIC_API_PORT;
-
-if (!host || !port) {
-  throw new Error('Missing LOCAL_HOST_URL or PORT in your environment');
-}
-const BASE_URL = `${host}:${port}`;
+console.log('BASE_URL:', BASE_URL);
 
 // This function is responsible for making the API call to create a user
 export async function createUser(request: UserRequest): Promise<CreatedUser> {


### PR DESCRIPTION
## 🚀 What does this PR do?

> Adds support for running the Expo app on physical devices by tunneling our local backend through ngrok.  
> - Updates backend to read a `PUBLIC_URL` (ngrok) alongside `LOCAL_HOST_URL` and whitelist both in CORS  
> - Updates frontend to pick `http://localhost:3001` for simulators/web and the ngrok HTTPS URL for real devices  
> - Ensures iPhones (and other hardware) can fetch API data (they can’t reach `localhost` directly)

---

## ✅ Checklist

- [x] Code compiles & runs
- [ ] Lint checks pass
- [x] Updated `.env.example` if needed
- [ ] PR linked to related issue/ticket (if applicable)

---

## 🔍 How to test this

1. **Install & log in to ngrok**  
   npm install -g ngrok
   ngrok config add-authtoken YOUR_NGROK_AUTH_TOKEN

2. **open another backend terminal:**
    run ngrok http 3001

3. **Configure backend env**
    LOCAL_URL=http://localhost:3001
    PORT=3001
    PUBLIC_URL=https://<your-id>.ngrok-free.app

4. **Configure frontend env**
   EXPO_PUBLIC_API_HOST=http://localhost
   EXPO_PUBLIC_API_PORT=3001
   EXPO_PUBLIC_API_PUBLIC_URL=https://<your-id>.ngrok-free.app

5. Scan the QR code with Expo Go on your iPhone (or Android device).
---
