### PR TITLE
fix bug room id not loading

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,12 +16,7 @@ const PUBLIC_URL = process.env.PUBLIC_URL;
 
 app.use(express.json({ limit: '20mb' })); // For JSON payloads
 app.use(express.urlencoded({ limit: '20mb', extended: true }));
-app.use(
-  cors({
-    origin: [LOCAL_URL, PUBLIC_URL].filter((u): u is string => !!u),
-  }),
-);
-
+app.use(cors());
 
 // Route mounting
 app.use('/users', UserRouter);

--- a/frontend/src/app/(onboard)/join-room.tsx
+++ b/frontend/src/app/(onboard)/join-room.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
 import Button from '@/components/Button';
@@ -6,6 +6,8 @@ import { View, Text, TextInput, Alert, Image } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { pairRoom, deleteRoom } from '@/apis/room';
 import { SignOutButton } from '@/components/SignOutButton';
+import { useAuth } from '@clerk/clerk-expo';
+import { fetchRoom } from '@/apis/room';
 
 function PairingStep({
   myCode,
@@ -88,11 +90,21 @@ function PairingStep({
 
 const JoinRoom = () => {
   const router = useRouter();
-  const { userId, roomId } = useLocalSearchParams();
-  const roomIdString = Array.isArray(roomId) ? roomId[0] : roomId;
+  const { userId } = useAuth();
+  const [roomId, setRoomId] = useState('');
   const [partnerCode, setPartnerCode] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false); // Add loading state
+
+  useEffect(() => {
+    const getRoom = async () => {
+      const room = await fetchRoom({ user_id: userId ?? '' });
+      setRoomId(room.room_id);
+    };
+    getRoom();
+  }, [userId]);
+
+  const roomIdString = Array.isArray(roomId) ? roomId[0] : roomId;
 
   const connectRoom = async () => {
     if (partnerCode === roomIdString) {


### PR DESCRIPTION
## 🚀 What does this PR do?

> A short summary of what’s changed and why.

during room pairing, if a user leaves or refreshes the page, the room id will disappear (since its pushed from onboarding). this fix uses useAuth to fetch userId and uses that userId fetch the room id, ensuring that even after page reload the room id does not disappear

---

## ✅ Checklist

- [ ] Code compiles & runs
- [ ] Lint checks pass
- [ ] Updated `.env.example` if needed
- [ ] PR linked to related issue/ticket (if applicable)

---

## 🔍 How to test this

> Describe how reviewers can test this — steps, screenshots, etc.

---

## 🧠 Extra Notes

> Any decisions made? Tradeoffs? Gotchas?
