### PR TITLE
clean up switch mode

### DIFF
--- a/backend/docs/models-uml.md
+++ b/backend/docs/models-uml.md
@@ -1,0 +1,225 @@
+# Backend Models — UML Class Diagram
+
+> Generated from `backend/src/models/`. Focus: primary keys, foreign keys, and entity relationships.
+
+## Mermaid Class Diagram
+
+```mermaid
+classDiagram
+    class User {
+        <<PK>> user_id
+    }
+
+    class Room {
+        <<PK>> room_id
+        <<FK>> user_1
+        <<FK>> user_2
+    }
+
+    class AccessToken {
+        <<FK>> user_id
+    }
+
+    class Library {
+        <<PK>> id
+        couple_id
+    }
+
+    class Entry {
+        <<PK>> id
+        <<FK>> book_id
+    }
+
+    class Event {
+        <<FK>> room_id
+        <<FK>> user_1
+        <<FK>> user_2
+    }
+
+    class Chat {
+        <<PK>> message_id
+        <<FK>> room_id
+        <<FK>> sender_id
+    }
+
+    class PlaybackCommand {
+        <<PK>> id
+        <<FK>> room_id
+        <<FK>> requested_by_user_id
+    }
+
+    class RoomYouTubeVideo {
+        <<PK>> id
+        <<FK>> room_id
+        <<FK>> added_by_user_id
+    }
+
+    class RoomSpotifyTrack {
+        <<PK>> id
+        <<FK>> room_id
+        <<FK>> added_by_user_id
+    }
+
+    class YouTubeVideo <<legacy>> {
+        <<PK>> id
+        <<FK>> user_id
+    }
+
+    class SpotifyTrack <<legacy>> {
+        <<PK>> id
+        <<FK>> user_id
+    }
+
+    User "1" -- "0..1" AccessToken : user_id
+    User "1" -- "0..*" Room : user_1
+    User "1" -- "0..*" Room : user_2
+    Room "1" -- "*" Chat : room_id
+    Room "1" -- "*" PlaybackCommand : room_id
+    Room "1" -- "0..1" RoomYouTubeVideo : room_id
+    Room "1" -- "0..1" RoomSpotifyTrack : room_id
+    Room "1" -- "*" Event : room_id
+    Library "1" -- "*" Entry : book_id
+    User "1" -- "*" Chat : sender_id
+    User "1" -- "*" PlaybackCommand : requested_by_user_id
+    User "1" -- "*" RoomYouTubeVideo : added_by_user_id
+    User "1" -- "*" RoomSpotifyTrack : added_by_user_id
+    User "1" -- "*" Event : user_1, user_2
+    User "1" -- "*" YouTubeVideo : user_id
+    User "1" -- "*" SpotifyTrack : user_id
+```
+
+## Entity-Relationship Diagram
+
+```mermaid
+erDiagram
+    User ||--o| AccessToken : "user_id"
+    User ||--o{ Room : "user_1"
+    User ||--o{ Room : "user_2"
+    Room ||--o{ Chat : "room_id"
+    Room ||--o{ PlaybackCommand : "room_id"
+    Room ||--o| RoomYouTubeVideo : "room_id"
+    Room ||--o| RoomSpotifyTrack : "room_id"
+    Room ||--o{ Event : "room_id"
+    Library ||--o{ Entry : "book_id"
+    User ||--o{ Chat : "sender_id"
+    User ||--o{ PlaybackCommand : "requested_by_user_id"
+    User ||--o{ RoomYouTubeVideo : "added_by_user_id"
+    User ||--o{ RoomSpotifyTrack : "added_by_user_id"
+    User ||--o{ Event : "user_1, user_2"
+    User ||--o{ YouTubeVideo : "user_id"
+    User ||--o{ SpotifyTrack : "user_id"
+
+    User {
+        string user_id PK
+    }
+
+    Room {
+        string room_id PK
+        string user_1 FK
+        string user_2 FK
+    }
+
+    AccessToken {
+        string user_id FK
+    }
+
+    Library {
+        string id PK
+        string couple_id
+    }
+
+    Entry {
+        string id PK
+        string book_id FK
+    }
+
+    Event {
+        string room_id FK
+        string user_1 FK
+        string user_2 FK
+    }
+
+    Chat {
+        string message_id PK
+        string room_id FK
+        string sender_id FK
+    }
+
+    PlaybackCommand {
+        string id PK
+        string room_id FK
+        string requested_by_user_id FK
+    }
+
+    RoomYouTubeVideo {
+        string id PK
+        string room_id FK
+        string added_by_user_id FK
+    }
+
+    RoomSpotifyTrack {
+        string id PK
+        string room_id FK
+        string added_by_user_id FK
+    }
+
+    YouTubeVideo {
+        string id PK
+        string user_id FK
+    }
+
+    SpotifyTrack {
+        string id PK
+        string user_id FK
+    }
+```
+
+## PK / FK Summary
+
+| Entity | Primary Key | Foreign Keys |
+|--------|-------------|--------------|
+| User | user_id | — |
+| Room | room_id | user_1 → User, user_2 → User |
+| AccessToken | — | user_id → User |
+| Library | id | — |
+| Entry | id | book_id → Library |
+| Event | — | room_id → Room, user_1 → User, user_2 → User |
+| Chat | message_id | room_id → Room, sender_id → User |
+| PlaybackCommand | id | room_id → Room, requested_by_user_id → User |
+| RoomYouTubeVideo | id | room_id → Room, added_by_user_id → User |
+| RoomSpotifyTrack | id | room_id → Room, added_by_user_id → User |
+| YouTubeVideo (legacy) | id | user_id → User |
+| SpotifyTrack (legacy) | id | user_id → User |
+
+## Relationship Graph
+
+```
+                    ┌──────────┐
+                    │   User   │
+                    │ user_id  │
+                    └────┬─────┘
+         ┌───────────────┼───────────────┬───────────────┬───────────────┬──────────────┐
+         │               │               │               │               │              │
+         ▼               ▼               ▼               ▼               ▼              ▼
+  ┌──────────────┐ ┌──────────┐  ┌──────────┐  ┌─────────────────┐ ┌─────────────────┐ ┌──────────┐
+  │ AccessToken  │ │   Room   │  │   Chat   │  │ RoomYouTubeVideo │ │ RoomSpotifyTrack│ │  Event   │
+  │  user_id    │ │ room_id  │  │msg_id   │  │       id         │ │       id        │ │ room_id  │
+  └──────────────┘ │ user_1   │  │ room_id  │  │ room_id          │ │ room_id         │ │ user_1   │
+                  │ user_2   │  │ sender_id│  │ added_by_user_id │ │ added_by_user_id│ │ user_2   │
+                  └────┬─────┘  └──────────┘  └─────────────────┘ └─────────────────┘ └──────────┘
+                       │
+         ┌─────────────┼─────────────┐
+         │             │             │
+         ▼             ▼             ▼
+  ┌──────────┐ ┌──────────────────┐ ┌──────────┐
+  │   Chat   │ │ PlaybackCommand   │ │  Event   │
+  │ room_id  │ │ room_id           │ │ room_id  │
+  └──────────┘ │ requested_by_uid  │ └──────────┘
+               └──────────────────┘
+
+  ┌──────────┐       book_id        ┌──────────┐
+  │ Library  │ ───────────────────▶│  Entry   │
+  │    id    │                      │    id    │
+  └──────────┘                      │ book_id  │
+                                    └──────────┘
+```

--- a/backend/src/controllers/spotifyController.ts
+++ b/backend/src/controllers/spotifyController.ts
@@ -41,6 +41,13 @@ export async function createRoomTrack(req: AuthenticatedRequest, res: Response):
       });
     }
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can modify Spotify state',
+      });
+      return;
+    }
     logger.spotify.error('Error in createRoomTrack controller:', error);
     res.status(500).json({
       success: false,
@@ -117,6 +124,13 @@ export async function updateRoomTrack(req: AuthenticatedRequest, res: Response):
       });
     }
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can modify Spotify state',
+      });
+      return;
+    }
     logger.spotify.error('Error in updateRoomTrack controller:', error);
     res.status(500).json({
       success: false,
@@ -156,6 +170,13 @@ export async function deleteRoomTrack(req: AuthenticatedRequest, res: Response):
       });
     }
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can modify Spotify state',
+      });
+      return;
+    }
     logger.spotify.error('Error in deleteRoomTrack controller:', error);
     res.status(500).json({
       success: false,
@@ -171,6 +192,15 @@ export async function deleteRoomTrackByRoomId(
   res: Response,
 ): Promise<void> {
   try {
+    const userId = req.user?.id;
+    if (!userId) {
+      res.status(401).json({
+        success: false,
+        message: 'User not authenticated',
+      });
+      return;
+    }
+
     const roomId = req.params.room_id;
     if (!roomId) {
       res.status(400).json({
@@ -182,7 +212,7 @@ export async function deleteRoomTrackByRoomId(
 
     logger.spotify.info('Deleting room Spotify track for room:', roomId);
 
-    const success = await spotifyService.deleteRoomTrackByRoomId(roomId);
+    const success = await spotifyService.deleteRoomTrackByRoomIdAsController(roomId, userId);
 
     if (success) {
       res.status(200).json({
@@ -196,6 +226,13 @@ export async function deleteRoomTrackByRoomId(
       });
     }
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can modify Spotify state',
+      });
+      return;
+    }
     logger.spotify.error('Error in deleteRoomTrackByRoomId controller:', error);
     res.status(500).json({
       success: false,
@@ -324,6 +361,7 @@ export async function playTrack(req: AuthenticatedRequest, res: Response): Promi
     }
 
     logger.spotify.info('Playing Spotify track:', { userId, track_uri });
+    await spotifyService.assertSpotifyControllerUser(userId);
 
     await spotifyService.playSpotifyTrack(userId, track_uri, accessToken);
 
@@ -332,6 +370,13 @@ export async function playTrack(req: AuthenticatedRequest, res: Response): Promi
       message: 'Track started playing successfully',
     });
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can control playback',
+      });
+      return;
+    }
     logger.spotify.error('Error in playTrack controller:', error);
     res.status(500).json({
       success: false,
@@ -356,6 +401,7 @@ export async function pausePlayback(req: AuthenticatedRequest, res: Response): P
     const accessToken = req.headers['x-spotify-access-token'] as string;
 
     logger.spotify.info('Pausing Spotify playback for user:', userId);
+    await spotifyService.assertSpotifyControllerUser(userId);
 
     await spotifyService.pauseSpotifyPlayback(userId, accessToken);
 
@@ -364,6 +410,13 @@ export async function pausePlayback(req: AuthenticatedRequest, res: Response): P
       message: 'Playback paused successfully',
     });
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can control playback',
+      });
+      return;
+    }
     logger.spotify.error('Error in pausePlayback controller:', error);
     res.status(500).json({
       success: false,
@@ -388,6 +441,7 @@ export async function skipToNext(req: AuthenticatedRequest, res: Response): Prom
     const accessToken = req.headers['x-spotify-access-token'] as string;
 
     logger.spotify.info('Skipping to next track for user:', userId);
+    await spotifyService.assertSpotifyControllerUser(userId);
 
     await spotifyService.skipToNextTrack(userId, accessToken);
 
@@ -396,6 +450,13 @@ export async function skipToNext(req: AuthenticatedRequest, res: Response): Prom
       message: 'Skipped to next track successfully',
     });
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can control playback',
+      });
+      return;
+    }
     logger.spotify.error('Error in skipToNext controller:', error);
     res.status(500).json({
       success: false,
@@ -420,6 +481,7 @@ export async function skipToPrevious(req: AuthenticatedRequest, res: Response): 
     const accessToken = req.headers['x-spotify-access-token'] as string;
 
     logger.spotify.info('Skipping to previous track for user:', userId);
+    await spotifyService.assertSpotifyControllerUser(userId);
 
     await spotifyService.skipToPreviousTrack(userId, accessToken);
 
@@ -428,6 +490,13 @@ export async function skipToPrevious(req: AuthenticatedRequest, res: Response): 
       message: 'Skipped to previous track successfully',
     });
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can control playback',
+      });
+      return;
+    }
     logger.spotify.error('Error in skipToPrevious controller:', error);
     res.status(500).json({
       success: false,
@@ -461,6 +530,7 @@ export async function setVolume(req: AuthenticatedRequest, res: Response): Promi
     }
 
     logger.spotify.info('Setting playback volume for user:', { userId, volume });
+    await spotifyService.assertSpotifyControllerUser(userId);
 
     await spotifyService.setPlaybackVolume(userId, volume, accessToken);
 
@@ -469,6 +539,13 @@ export async function setVolume(req: AuthenticatedRequest, res: Response): Promi
       message: 'Volume set successfully',
     });
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      res.status(403).json({
+        success: false,
+        message: 'Only the active controller can control playback',
+      });
+      return;
+    }
     logger.spotify.error('Error in setVolume controller:', error);
     res.status(500).json({
       success: false,

--- a/backend/src/services/spotifyService.ts
+++ b/backend/src/services/spotifyService.ts
@@ -57,6 +57,48 @@ export interface SpotifyTrack {
   uri: string;
 }
 
+async function assertUserIsControllerForOwnRoom(userId: string): Promise<string> {
+  const roomId = await getRoomIdForUser(userId);
+  if (!roomId) {
+    throw new Error('User is not in a room');
+  }
+
+  const room = await roomService.getRoomById(roomId);
+  if (!room) {
+    throw new Error('Room not found');
+  }
+
+  const controllerId = room.playback_state?.controlled_by_user_id || room.user_1;
+  if (controllerId !== userId) {
+    throw new Error('FORBIDDEN_CONTROLLER_ONLY');
+  }
+
+  return roomId;
+}
+
+async function assertUserIsHostForRoom(userId: string, roomId: string): Promise<void> {
+  const room = await roomService.getRoomById(roomId);
+  if (!room) {
+    throw new Error('Room not found');
+  }
+
+  if (room.user_1 !== userId) {
+    throw new Error('FORBIDDEN_HOST_ONLY');
+  }
+}
+
+async function assertUserIsControllerForRoom(userId: string, roomId: string): Promise<void> {
+  const room = await roomService.getRoomById(roomId);
+  if (!room) {
+    throw new Error('Room not found');
+  }
+
+  const controllerId = room.playback_state?.controlled_by_user_id || room.user_1;
+  if (controllerId !== userId) {
+    throw new Error('FORBIDDEN_CONTROLLER_ONLY');
+  }
+}
+
 /**
  * Get Spotify access token from Supabase user metadata
  */
@@ -99,18 +141,15 @@ export async function createRoomTrack(
   request: CreateRoomSpotifyTrackRequest,
 ): Promise<RoomSpotifyTrack | null> {
   try {
-    // Use the authenticated user's ID from the request
-    const userId = req.user?.id || request.user_id;
+    // Use only the authenticated user's ID from the request
+    const userId = req.user?.id;
 
     if (!userId) {
       throw new Error('User not authenticated');
     }
 
-    // Get the room ID for the user
-    const roomId = await getRoomIdForUser(userId);
-    if (!roomId) {
-      throw new Error('User is not in a room');
-    }
+    // Controller-only writes: only current controller can change shared Spotify state
+    const roomId = await assertUserIsControllerForOwnRoom(userId);
 
     const input: CreateRoomSpotifyTrackInput = {
       room_id: roomId,
@@ -180,11 +219,8 @@ export async function updateRoomTrack(
   request: UpdateRoomSpotifyTrackRequest,
 ): Promise<RoomSpotifyTrack | null> {
   try {
-    // Get the room ID for the user
-    const roomId = await getRoomIdForUser(user_id);
-    if (!roomId) {
-      throw new Error('User is not in a room');
-    }
+    // Controller-only writes: only current controller can change shared Spotify state
+    const roomId = await assertUserIsControllerForOwnRoom(user_id);
 
     // Get the current track to verify it exists
     const currentTrack = await getRoomSpotifyTrack(roomId);
@@ -211,12 +247,8 @@ export async function deleteRoomTrack(user_id: string): Promise<boolean> {
   try {
     console.log('🎵 [DEBUG] Deleting room track for user:', user_id);
 
-    // Get the room ID for the user
-    const roomId = await getRoomIdForUser(user_id);
-    if (!roomId) {
-      console.log('🎵 [DEBUG] User is not in a room');
-      return false; // Return false instead of throwing error
-    }
+    // Controller-only writes: only current controller can change shared Spotify state
+    const roomId = await assertUserIsControllerForOwnRoom(user_id);
 
     // Get the current track to verify it exists
     const currentTrack = await getRoomSpotifyTrack(roomId);
@@ -243,6 +275,9 @@ export async function deleteRoomTrack(user_id: string): Promise<boolean> {
 
     return success;
   } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_CONTROLLER_ONLY') {
+      throw error;
+    }
     logger.spotify.error('Error in deleteRoomTrack service:', error);
     return false; // Return false instead of throwing error
   }
@@ -283,6 +318,26 @@ export async function deleteRoomTrackByRoomId(room_id: string): Promise<boolean>
     logger.spotify.error('Error in deleteRoomTrackByRoomId service:', error);
     return false; // Return false instead of throwing error
   }
+}
+
+export async function deleteRoomTrackByRoomIdAsHost(
+  room_id: string,
+  requesterUserId: string,
+): Promise<boolean> {
+  await assertUserIsHostForRoom(requesterUserId, room_id);
+  return deleteRoomTrackByRoomId(room_id);
+}
+
+export async function deleteRoomTrackByRoomIdAsController(
+  room_id: string,
+  requesterUserId: string,
+): Promise<boolean> {
+  await assertUserIsControllerForRoom(requesterUserId, room_id);
+  return deleteRoomTrackByRoomId(room_id);
+}
+
+export async function assertSpotifyControllerUser(userId: string): Promise<void> {
+  await assertUserIsControllerForOwnRoom(userId);
 }
 
 /**

--- a/frontend/src/app/(tabs)/home.tsx
+++ b/frontend/src/app/(tabs)/home.tsx
@@ -29,7 +29,6 @@ import {
 } from '@/apis/spotify';
 import { useApiClient } from '@/hooks/useApiClient';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useSpotifyPlayback } from '@/hooks/useSpotifyPlayback';
 import { SpotifyWidget } from '@/components/music/SpotifyWidget';
 import { TimeWidget } from '@/components/TimeWidget';
 import { WeatherWidget } from '@/components/WeatherWidget';
@@ -38,6 +37,7 @@ import { Ionicons, FontAwesome } from '@expo/vector-icons';
 import { locationTrackingService } from '@/services/locationTracking';
 import { updateUserLocation } from '@/apis/user';
 import Profile from '@/screens/Profile';
+import { sendPlayTrackCommand } from '@/services/playbackCommands';
 
 // WidgetCard component
 const WidgetCard = ({
@@ -124,9 +124,6 @@ const Home = () => {
       }, 500);
     }
   }, [roomId, refetchRoomTrack]);
-
-  // Real Spotify playback controls - only use when connected
-  const { playTrack, playbackState } = useSpotifyPlayback();
 
   useEffect(() => {
     if (userId) {
@@ -256,9 +253,13 @@ const Home = () => {
       // Refetch the room track to update the UI
       await refetchRoomTrack();
 
-      // Automatically play the track when added
+      // Automatically play via room command relay so there is one control path.
       try {
-        await playTrack(trackData.track_uri);
+        if (!roomId) {
+          throw new Error('Room not available for playback command');
+        }
+
+        await sendPlayTrackCommand(roomId, trackData.track_uri, userId);
         Alert.alert('Success!', `Now playing: ${trackData.track_name}`);
       } catch (playError: any) {
         let errorMessage = `${trackData.track_name} was added to your room, but couldn't start playing automatically.`;
@@ -311,6 +312,8 @@ const Home = () => {
   };
 
   const canAddVideo = hasRoom && (!roomVideo || roomVideo.added_by_user_id === userId);
+  const controllerId = roomTrack?.controlled_by_user_id;
+  const canControlSpotify = !roomId || controllerId === userId || (!controllerId && isHost);
 
   if (isLoading) {
     return (
@@ -501,15 +504,18 @@ const Home = () => {
           </Text>
 
           <View
-            className={roomTrack?.track_uri || playbackState?.currentTrack ? 'h-[420px]' : 'h-60'}
+            className={roomTrack?.track_uri ? 'h-[420px]' : 'h-60'}
           >
             <SpotifyWidget
               roomId={roomId || undefined}
-              canControl={true}
+              canControl={canControlSpotify}
+              canSwitchController={!!roomId && isHost}
               onPress={
-                roomTrack?.controlled_by_user_id === userId
-                  ? handleRemoveSpotifyTrack
-                  : () => setShowSpotifyInput(true)
+                canControlSpotify
+                  ? roomTrack?.controlled_by_user_id === userId
+                    ? handleRemoveSpotifyTrack
+                    : () => setShowSpotifyInput(true)
+                  : undefined
               }
               className="h-full"
             />

--- a/frontend/src/components/music/SpotifyWidget.tsx
+++ b/frontend/src/components/music/SpotifyWidget.tsx
@@ -3,15 +3,18 @@ import { View, StyleSheet, Text, TouchableOpacity, Image, Alert } from 'react-na
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@clerk/clerk-expo';
 import { useSharedSpotifyTrack, SharedSpotifyTrack } from '../../hooks/useSharedSpotifyTrack';
+import { useSharedPlayback } from '../../hooks/useSharedPlayback';
+import { usePlaybackCommandListener } from '../../hooks/usePlaybackCommandListener';
 import { useSpotifyPlayback } from '../../hooks/useSpotifyPlayback';
 import { useSpotifyAuth } from '../../hooks/useSpotifyAuth';
-import { spotifyService } from '../../services/spotifyService';
+import { sendPlaybackCommand } from '../../services/playbackCommands';
 
 type Props = {
   roomId?: string;
   onPress?: () => void;
   className?: string;
   canControl?: boolean;
+  canSwitchController?: boolean;
   isLoading?: boolean;
 };
 
@@ -59,6 +62,7 @@ export function SpotifyWidget({
   onPress,
   className = '',
   canControl = false,
+  canSwitchController = false,
   isLoading = false,
 }: Props) {
   const { userId } = useAuth();
@@ -68,9 +72,18 @@ export function SpotifyWidget({
     connect: connectSpotify,
     disconnect: disconnectSpotify,
   } = useSpotifyAuth();
-  const { track, updateTrack, clearTrack } = useSharedSpotifyTrack(roomId || null);
+  const { track, updateTrack, clearTrack, switchController } = useSharedSpotifyTrack(
+    roomId || null,
+  );
+  const { sharedPlaybackState } = useSharedPlayback(roomId || null);
   const { playbackState, togglePlayPause, skipToNext, skipToPrevious } = useSpotifyPlayback();
-  const [isPlaying, setIsPlaying] = useState(false);
+  const [isSwitchingController, setIsSwitchingController] = useState(false);
+
+  // Determine if user is controlling the playback (in room mode)
+  const isController = track?.controlled_by_user_id === userId;
+
+  // Controller listens for room playback commands and executes them on Spotify.
+  usePlaybackCommandListener(roomId || '', !!roomId && !!isController);
 
   // Derive connection state from Supabase auth status
   const isConnected = spotifyStatus === 'connected';
@@ -98,12 +111,9 @@ export function SpotifyWidget({
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
-  // Update isPlaying state based on Spotify playback state
-  useEffect(() => {
-    if (playbackState) {
-      setIsPlaying(playbackState.isPlaying);
-    }
-  }, [playbackState]);
+  const isPlaying = roomId
+    ? !!sharedPlaybackState?.is_playing
+    : !!playbackState?.isPlaying;
 
   // Handle play/pause
   const handlePlayPause = async () => {
@@ -112,11 +122,46 @@ export function SpotifyWidget({
     }
 
     try {
-      // Always use Spotify API directly for play/pause control
-      await togglePlayPause();
+      // Room mode: relay command so controller executes exactly one playback path.
+      if (roomId) {
+        await sendPlaybackCommand(roomId, isPlaying ? 'pause' : 'play', currentTrack.track_uri, {
+          requested_by_user_id: userId || undefined,
+        });
+        return;
+      }
 
-      // Update local state after successful API call
-      setIsPlaying(!isPlaying);
+      // Solo mode: direct Spotify control.
+      await togglePlayPause();
+    } catch (error) {
+      // Silently handle errors without showing alerts
+    }
+  };
+
+  const handleNext = async () => {
+    try {
+      if (roomId) {
+        await sendPlaybackCommand(roomId, 'next', undefined, {
+          requested_by_user_id: userId || undefined,
+        });
+        return;
+      }
+
+      await skipToNext();
+    } catch (error) {
+      // Silently handle errors without showing alerts
+    }
+  };
+
+  const handlePrevious = async () => {
+    try {
+      if (roomId) {
+        await sendPlaybackCommand(roomId, 'previous', undefined, {
+          requested_by_user_id: userId || undefined,
+        });
+        return;
+      }
+
+      await skipToPrevious();
     } catch (error) {
       // Silently handle errors without showing alerts
     }
@@ -131,6 +176,19 @@ export function SpotifyWidget({
       if (onPress) onPress();
     } catch (error) {
       // Silently handle errors without showing alerts
+    }
+  };
+
+  const handleSwitchController = async () => {
+    if (!roomId || isSwitchingController || !canSwitchController) return;
+
+    try {
+      setIsSwitchingController(true);
+      await switchController();
+    } catch (error) {
+      Alert.alert('Error', 'Failed to switch controller. Please try again.');
+    } finally {
+      setIsSwitchingController(false);
     }
   };
 
@@ -219,29 +277,31 @@ export function SpotifyWidget({
             >
               Search for a song to share with your partner
             </Text>
-            <TouchableOpacity
-              onPress={onPress}
-              className="bg-[#6536DD] border-2 border-black"
-              style={{
-                shadowColor: '#000',
-                shadowOffset: { width: 2, height: 2 },
-                shadowOpacity: 1,
-                shadowRadius: 0,
-                elevation: 4,
-              }}
-            >
-              <View className="bg-[#6536DD] px-6 py-3">
-                <Text
-                  style={{
-                    fontFamily: 'PixelifySans',
-                    fontSize: 14,
-                  }}
-                  className="text-white"
-                >
-                  Search Music
-                </Text>
-              </View>
-            </TouchableOpacity>
+            {canControl && onPress && (
+              <TouchableOpacity
+                onPress={onPress}
+                className="bg-[#6536DD] border-2 border-black"
+                style={{
+                  shadowColor: '#000',
+                  shadowOffset: { width: 2, height: 2 },
+                  shadowOpacity: 1,
+                  shadowRadius: 0,
+                  elevation: 4,
+                }}
+              >
+                <View className="bg-[#6536DD] px-6 py-3">
+                  <Text
+                    style={{
+                      fontFamily: 'PixelifySans',
+                      fontSize: 14,
+                    }}
+                    className="text-white"
+                  >
+                    Search Music
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            )}
           </View>
         </View>
       </View>
@@ -252,9 +312,6 @@ export function SpotifyWidget({
     currentTrack?.duration_ms && currentTrack.duration_ms > 0
       ? ((playbackState?.progress || 0) / currentTrack.duration_ms) * 100
       : 0;
-
-  // Determine if user is controlling the playback
-  const isController = track?.controlled_by_user_id === userId;
 
   return (
     <View
@@ -283,7 +340,7 @@ export function SpotifyWidget({
         </TouchableOpacity>
 
         {/* Delete Button positioned on the right - only show if onPress is provided */}
-        {onPress && (
+        {canControl && onPress && (
           <TouchableOpacity
             onPress={handleRemoveTrack}
             style={[
@@ -308,17 +365,50 @@ export function SpotifyWidget({
       <View className="bg-white px-4 py-4 rounded-b-md flex-1">
         {/* Controller indicator */}
         {roomId && (
-          <View className="flex-row items-center justify-center mb-2">
-            <Ionicons name="radio" size={12} color="#6536DD" />
-            <Text
-              style={{
-                fontFamily: 'PixelifySans',
-                fontSize: 12,
-              }}
-              className="text-black ml-1"
-            >
-              {isController ? 'You control' : 'Partner controls'}
-            </Text>
+          <View className="mb-2">
+            <View className="flex-row items-center justify-center">
+              <Ionicons name="radio" size={12} color="#6536DD" />
+              <Text
+                style={{
+                  fontFamily: 'PixelifySans',
+                  fontSize: 12,
+                }}
+                className="text-black ml-1"
+              >
+                {isController ? 'You control' : 'Partner controls'}
+              </Text>
+            </View>
+            <View className="items-center mt-2">
+              <TouchableOpacity
+                onPress={handleSwitchController}
+                disabled={isSwitchingController || !canSwitchController}
+                className="bg-[#6536DD] border-2 border-black"
+                style={{
+                  shadowColor: '#000',
+                  shadowOffset: { width: 2, height: 2 },
+                  shadowOpacity: 1,
+                  shadowRadius: 0,
+                  elevation: 4,
+                  opacity: isSwitchingController || !canSwitchController ? 0.7 : 1,
+                }}
+              >
+                <View className="bg-[#6536DD] px-3 py-1">
+                  <Text
+                    style={{
+                      fontFamily: 'PixelifySans',
+                      fontSize: 12,
+                    }}
+                    className="text-white"
+                  >
+                    {!canSwitchController
+                      ? 'Host Only'
+                      : isSwitchingController
+                        ? 'Switching...'
+                        : 'Switch Controller'}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
           </View>
         )}
 
@@ -367,7 +457,7 @@ export function SpotifyWidget({
           {canControl && (
             <View style={styles.controls}>
               <TouchableOpacity
-                onPress={skipToPrevious}
+                onPress={handlePrevious}
                 style={[styles.controlButton, !canControl && styles.disabledButton]}
                 disabled={!canControl}
               >
@@ -389,7 +479,7 @@ export function SpotifyWidget({
               </TouchableOpacity>
 
               <TouchableOpacity
-                onPress={skipToNext}
+                onPress={handleNext}
                 style={[styles.controlButton, !canControl && styles.disabledButton]}
                 disabled={!canControl}
               >

--- a/frontend/src/hooks/usePlaybackCommandListener.ts
+++ b/frontend/src/hooks/usePlaybackCommandListener.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useCallback } from 'react';
-import { useAuth } from '@clerk/clerk-expo';
 import { spotifyService } from '@/services/spotifyService';
 import supabase from '@/utils/supabase';
 import { logger } from '@/utils/logger';
@@ -14,7 +13,6 @@ interface PlaybackCommand {
 }
 
 export function usePlaybackCommandListener(roomId: string, isController: boolean) {
-  const { userId } = useAuth();
   const lastCommandTime = useRef<number>(0);
   const isExecuting = useRef<boolean>(false);
 
@@ -142,17 +140,13 @@ export function usePlaybackCommandListener(roomId: string, isController: boolean
           table: 'playback_commands',
           filter: `room_id=eq.${roomId}`,
         },
-        (payload) => {
+        (payload: any) => {
           const command = payload.new as PlaybackCommand;
           logger.spotify.debug('Received playback command:', command);
-
-          // Only execute commands from other users (or anonymous commands)
-          if (!command.requested_by_user_id || command.requested_by_user_id !== userId) {
-            debouncedExecuteCommand(command);
-          }
+          debouncedExecuteCommand(command);
         },
       )
-      .subscribe((status) => {
+      .subscribe((status: string) => {
         logger.spotify.debug('Playback command subscription status:', status);
         if (status === 'SUBSCRIBED') {
           logger.spotify.info('Successfully subscribed to playback commands for room:', roomId);
@@ -163,7 +157,7 @@ export function usePlaybackCommandListener(roomId: string, isController: boolean
       logger.spotify.debug('Cleaning up playback command listener for room:', roomId);
       supabase.removeChannel(channel);
     };
-  }, [roomId, isController, userId, debouncedExecuteCommand]);
+  }, [roomId, isController, debouncedExecuteCommand]);
 
   return {
     isController,

--- a/frontend/src/hooks/useSharedSpotifyTrack.ts
+++ b/frontend/src/hooks/useSharedSpotifyTrack.ts
@@ -6,7 +6,9 @@ import {
   createRoomSpotifyTrack,
   deleteRoomSpotifyTrackByRoomId,
 } from '../apis/spotify';
+import { switchRoomPlaybackController } from '../services/playbackState';
 import { logger } from '../utils/logger';
+import supabase from '../utils/supabase';
 
 export interface SharedSpotifyTrack {
   track_uri: string | null;
@@ -26,6 +28,32 @@ export function useSharedSpotifyTrack(roomId: string | null) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const subscriptionRef = useRef<any>(null);
+
+  const syncControllerFromRoomState = useCallback(async () => {
+    if (!roomId) return;
+
+    try {
+      const { data } = await supabase
+        .from('room')
+        .select('playback_state')
+        .eq('room_id', roomId)
+        .single();
+
+      const controllerId = data?.playback_state?.controlled_by_user_id as string | undefined;
+      if (!controllerId) return;
+
+      setTrack((prev: SharedSpotifyTrack | null) =>
+        prev
+          ? {
+              ...prev,
+              controlled_by_user_id: controllerId,
+            }
+          : prev,
+      );
+    } catch (err) {
+      // Keep silent to avoid impacting existing Spotify behavior.
+    }
+  }, [roomId]);
 
   // Fetch initial track data using backend API
   const fetchTrack = useCallback(async () => {
@@ -133,6 +161,25 @@ export function useSharedSpotifyTrack(roomId: string | null) {
     }
   };
 
+  const switchController = async () => {
+    if (!roomId || !userId) return;
+
+    try {
+      const result = await switchRoomPlaybackController(roomId, userId);
+      setTrack((prev: SharedSpotifyTrack | null) =>
+        prev
+          ? {
+              ...prev,
+              controlled_by_user_id: result.controlled_by_user_id,
+            }
+          : prev,
+      );
+    } catch (err) {
+      setError('Failed to switch controller');
+      throw err;
+    }
+  };
+
   // Set up real-time subscription (keep this for now, but we'll rely more on manual refetching)
   useEffect(() => {
     if (!roomId) {
@@ -160,12 +207,48 @@ export function useSharedSpotifyTrack(roomId: string | null) {
     };
   }, [roomId, userId, fetchTrack]);
 
+  useEffect(() => {
+    if (!roomId) return;
+
+    syncControllerFromRoomState();
+
+    const roomChannel = supabase
+      .channel(`room_controller_${roomId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'room',
+          filter: `room_id=eq.${roomId}`,
+        },
+        (payload: any) => {
+          const controllerId = payload.new?.playback_state?.controlled_by_user_id;
+          if (!controllerId) return;
+          setTrack((prev: SharedSpotifyTrack | null) =>
+            prev
+              ? {
+                  ...prev,
+                  controlled_by_user_id: controllerId,
+                }
+              : prev,
+          );
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(roomChannel);
+    };
+  }, [roomId, syncControllerFromRoomState]);
+
   return {
     track,
     isLoading,
     error,
     updateTrack,
     clearTrack,
+    switchController,
     refetch: fetchTrack,
   };
 }

--- a/frontend/src/services/playbackCommands.ts
+++ b/frontend/src/services/playbackCommands.ts
@@ -1,4 +1,3 @@
-import { ApiClient } from '../apis/apiClient';
 import { logger } from '../utils/logger';
 import supabase from '../utils/supabase';
 
@@ -54,48 +53,52 @@ async function getSpotifyAccessToken(): Promise<string | null> {
   }
 }
 
+type PlaybackCommandType = PlaybackCommand['command'];
+
 /**
- * Send a playback command to the backend
+ * Send a playback command into room relay channel.
+ * This writes to Supabase `playback_commands` table, which controller clients
+ * subscribe to via real-time listener.
  */
 export async function sendPlaybackCommand(
   roomId: string,
-  command: PlaybackCommand,
-  userId: string,
-  apiClient: ApiClient,
+  command: PlaybackCommandType,
+  track_uri?: string,
+  options?: {
+    position_ms?: number;
+    volume?: number;
+    requested_by_user_id?: string;
+  },
 ): Promise<PlaybackCommandResponse> {
   try {
-    logger.spotify.debug('Sending playback command:', { roomId, command, userId });
+    const payload = {
+      room_id: roomId,
+      command,
+      track_uri,
+      position_ms: options?.position_ms,
+      volume: options?.volume,
+      requested_at: new Date().toISOString(),
+      requested_by_user_id: options?.requested_by_user_id,
+    };
 
-    // Get the Spotify access token
-    const accessToken = await getSpotifyAccessToken();
+    logger.spotify.debug('Sending playback command:', payload);
 
-    // Prepare headers with Spotify access token if available
-    const headers: Record<string, string> = {};
-    if (accessToken) {
-      headers['x-spotify-access-token'] = accessToken;
+    const { data, error } = await supabase
+      .from('playback_commands')
+      .insert(payload)
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
     }
 
-    // Send the command to the backend
-    const response = await apiClient.post(
-      `/playback-commands`,
-      {
-        room_id: roomId,
-        user_id: userId,
-        command: command.command,
-        track_uri: command.track_uri,
-        position_ms: command.position_ms,
-        volume: command.volume,
-      },
-      undefined, // userToken
-      headers,
-    );
-
-    logger.spotify.debug('Playback command response:', response);
+    logger.spotify.debug('Playback command response:', data);
 
     return {
       success: true,
       message: 'Command sent successfully',
-      data: response,
+      data,
     };
   } catch (error) {
     logger.spotify.error('Error sending playback command:', error);
@@ -107,21 +110,43 @@ export async function sendPlaybackCommand(
 }
 
 /**
+ * Convenience helper to send play command with a required track URI.
+ */
+export async function sendPlayTrackCommand(
+  roomId: string,
+  trackUri: string,
+  requestedByUserId?: string,
+): Promise<PlaybackCommandResponse> {
+  return sendPlaybackCommand(roomId, 'play', trackUri, {
+    position_ms: 0,
+    requested_by_user_id: requestedByUserId,
+  });
+}
+
+/**
  * Get playback commands for a room
  */
 export async function getPlaybackCommands(
   roomId: string,
-  apiClient: ApiClient,
 ): Promise<PlaybackCommandResponse> {
   try {
     logger.spotify.debug('Getting playback commands for room:', roomId);
 
-    const response = await apiClient.get(`/playback-commands?room_id=${roomId}`);
+    const { data, error } = await supabase
+      .from('playback_commands')
+      .select('*')
+      .eq('room_id', roomId)
+      .order('created_at', { ascending: false })
+      .limit(20);
+
+    if (error) {
+      throw error;
+    }
 
     return {
       success: true,
       message: 'Commands retrieved successfully',
-      data: response,
+      data,
     };
   } catch (error) {
     logger.spotify.error('Error getting playback commands:', error);
@@ -137,17 +162,20 @@ export async function getPlaybackCommands(
  */
 export async function deletePlaybackCommands(
   roomId: string,
-  apiClient: ApiClient,
 ): Promise<PlaybackCommandResponse> {
   try {
     logger.spotify.debug('Deleting playback commands for room:', roomId);
 
-    const response = await apiClient.delete(`/playback-commands?room_id=${roomId}`);
+    const { error } = await supabase.from('playback_commands').delete().eq('room_id', roomId);
+
+    if (error) {
+      throw error;
+    }
 
     return {
       success: true,
       message: 'Commands deleted successfully',
-      data: response,
+      data: null,
     };
   } catch (error) {
     logger.spotify.error('Error deleting playback commands:', error);

--- a/frontend/src/services/playbackState.ts
+++ b/frontend/src/services/playbackState.ts
@@ -26,3 +26,60 @@ export async function getPlaybackState(roomId: string) {
   if (error) throw error;
   return data;
 }
+
+type RoomPlaybackState = {
+  is_playing?: boolean;
+  current_track_uri?: string | null;
+  progress_ms?: number;
+  controlled_by_user_id?: string | null;
+};
+
+type RoomControllerSwitchResult = {
+  controlled_by_user_id: string;
+};
+
+export async function switchRoomPlaybackController(
+  roomId: string,
+  currentUserId: string,
+): Promise<RoomControllerSwitchResult> {
+  const { data: roomData, error: roomError } = await supabase
+    .from('room')
+    .select('user_1, user_2, playback_state')
+    .eq('room_id', roomId)
+    .single();
+
+  if (roomError || !roomData) {
+    throw roomError || new Error('Room not found');
+  }
+
+  // Host-client model: only host (user_1) can change controller ownership.
+  if (roomData.user_1 !== currentUserId) {
+    throw new Error('Only the room host can switch controller');
+  }
+
+  const user1 = roomData.user_1 as string | null;
+  const user2 = roomData.user_2 as string | null;
+  if (!user1 || !user2) {
+    throw new Error('Both users must be in the room to switch controller');
+  }
+
+  const playbackState: RoomPlaybackState = roomData.playback_state || {};
+  const currentController = playbackState.controlled_by_user_id || currentUserId;
+  const nextController = currentController === user1 ? user2 : user1;
+
+  const nextPlaybackState: RoomPlaybackState = {
+    ...playbackState,
+    controlled_by_user_id: nextController,
+  };
+
+  const { error: updateError } = await supabase
+    .from('room')
+    .update({ playback_state: nextPlaybackState })
+    .eq('room_id', roomId);
+
+  if (updateError) {
+    throw updateError;
+  }
+
+  return { controlled_by_user_id: nextController };
+}


### PR DESCRIPTION
This pull request introduces stricter access control for Spotify-related actions in rooms, ensuring that only the designated controller can modify playback state or tracks. It also adds improved error handling and authentication checks, and expands documentation of backend models and their relationships.

Access control improvements for Spotify actions:

* Added controller-only checks to all Spotify playback and track modification endpoints in `spotifyController.ts`, using `spotifyService.assertSpotifyControllerUser` to ensure only the active controller can perform these actions. If a non-controller attempts an action, a 403 error is returned with an appropriate message. [[1]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR364) [[2]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR373-R379) [[3]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR404) [[4]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR413-R419) [[5]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR444) [[6]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR453-R459) [[7]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR484) [[8]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR493-R499) [[9]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR533) [[10]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR542-R548)
* Refactored `spotifyService.ts` to implement controller/host assertion helpers (`assertUserIsControllerForOwnRoom`, `assertUserIsControllerForRoom`, `assertUserIsHostForRoom`) and to enforce controller-only writes for track creation, updating, and deletion. [[1]](diffhunk://#diff-22d585cd289c1073f2ab394956c5b8d36ceb75dbe519ae6c9133cab1a86e626cR60-R101) [[2]](diffhunk://#diff-22d585cd289c1073f2ab394956c5b8d36ceb75dbe519ae6c9133cab1a86e626cL102-R152) [[3]](diffhunk://#diff-22d585cd289c1073f2ab394956c5b8d36ceb75dbe519ae6c9133cab1a86e626cL183-R223) [[4]](diffhunk://#diff-22d585cd289c1073f2ab394956c5b8d36ceb75dbe519ae6c9133cab1a86e626cL214-R251) [[5]](diffhunk://#diff-22d585cd289c1073f2ab394956c5b8d36ceb75dbe519ae6c9133cab1a86e626cR278-R280) [[6]](diffhunk://#diff-22d585cd289c1073f2ab394956c5b8d36ceb75dbe519ae6c9133cab1a86e626cR323-R342)

Authentication and error handling:

* Added explicit authentication checks and improved error responses in `deleteRoomTrackByRoomId` and other controller endpoints, including handling for unauthenticated users and forbidden actions. [[1]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR195-R203) [[2]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dL185-R215) [[3]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR229-R235) [[4]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR44-R50) [[5]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR127-R133) [[6]](diffhunk://#diff-82748640176ba35819af424ce5a808132872ab185aefcf7ac85c8c46120b094dR173-R179)

Documentation:

* Added a comprehensive UML and entity-relationship diagram for backend models in `backend/docs/models-uml.md`, detailing primary keys, foreign keys, and relationships between entities.## 🚀 What does this PR do?

> A short summary of what’s changed and why.

---

## ✅ Checklist

- [ ] Code compiles & runs
- [ ] Lint checks pass
- [ ] Updated `.env.example` if needed
- [ ] PR linked to related issue/ticket (if applicable)

---

## 🔍 How to test this

> Describe how reviewers can test this — steps, screenshots, etc.

---

## 🧠 Extra Notes

> Any decisions made? Tradeoffs? Gotchas?
